### PR TITLE
fix: duplicated versions are shown with list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,7 +14,7 @@ function osx_versions () {
 }
 
 function cabal_versions () {
-  curl -sL "$cabal_releases" | grep -oE 'package/idris-[0-9\.]+' | uniq | sed 's|package/idris-||'
+  curl -sL "$cabal_releases" | grep -oE 'package/idris-[0-9\.]+' | sort -u | sed 's|package/idris-||'
 }
 
 if [ "${ASDF_IDRIS_INSTALL}" == "cabal" -o "Darwin" != "$(uname -s)" ]; then


### PR DESCRIPTION
`uniq` works on adjacent lines and does not remove duplicated versions as expected.